### PR TITLE
fix(deploy): clean Alembic + robust entrypoint + audit hooks

### DIFF
--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -7,8 +7,6 @@ if [ -f ./alembic.ini ]; then
   echo "[entrypoint] Running Alembic migrations..."
   # show heads; NEVER pass '-n -20'
   alembic heads || true
-  # short history for context (optional)
-  alembic history -n 20 || true
   # single-head path, else merge-heads path
   alembic upgrade head || alembic upgrade heads
 fi


### PR DESCRIPTION
- Remove unsupported 'alembic heads -n ...' flag in entrypoint; run 'alembic upgrade head' with safe fallback.
- Make order_id FK migrations idempotent & add robust backfill.
- Register audit hooks to populate audit_logs.order_code on insert.
- Ensure Dockerfile copies entrypoint, strips CRLF, sets ENTRYPOINT.
- Normalize line endings for .sh via .gitattributes.